### PR TITLE
Monadic goodness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Minor release before 1.0.0 may include breaking changes and will explicitly mark
 
 ## Next Release
 
+* [core] Add a `algo.monad` instance for Finagle futures. Also add a `dofuture` macro which is a thin layer over `domonad` from `algo.monads`. 
+  This is intended to serve as a replacement for [the custom sequencing macro](https://github.com/finagle/finagle-clojure/blob/v0.1.1/core/src/finagle_clojure/futures.clj#L169-L181)
+  that we have at present.
+
 ## Version 0.3.0
 
 * [mysql] Add support for finagle-mysql (thanks [@bguthrie](http://github.com/bguthrie)!). [PR](https://github.com/finagle/finagle-clojure/pull/6)

--- a/core/project.clj
+++ b/core/project.clj
@@ -11,4 +11,5 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha5"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
-  :dependencies [[com.twitter/finagle-core_2.10 "6.24.0"]])
+  :dependencies [[com.twitter/finagle-core_2.10 "6.24.0"]
+                 [org.clojure/algo.monads "0.1.5"]])

--- a/core/src/finagle_clojure/monad.clj
+++ b/core/src/finagle_clojure/monad.clj
@@ -1,0 +1,16 @@
+(ns finagle-clojure.monad
+  (:use [clojure.algo.monads :only [defmonad domonad]])
+  (:require [finagle-clojure.futures :as f]))
+
+(defmonad future-monad
+          [m-result f/value
+
+           m-bind (fn [a-future fun]
+                    (f/flatmap a-future [x#] (fun x#)))
+
+           m-map (fn [a-future fun]
+                   (f/map a-future [x#] (fun x#)))])
+
+(defmacro dofuture [& forms]
+  `(domonad future-monad
+            ~@forms))

--- a/core/test/finagle_clojure/monad_test.clj
+++ b/core/test/finagle_clojure/monad_test.clj
@@ -1,0 +1,12 @@
+(ns finagle-clojure.monad-test
+  (:require [clojure.algo.monads :refer [domonad]]
+            [finagle-clojure.monad :refer :all]
+            [finagle-clojure.futures :as f]
+            [midje.sweet :refer :all]))
+
+(fact "The monadic expansion"
+      (f/await
+        (dofuture [x (f/value 9)
+                   y (f/value "stuff")]
+                  (str x y)))
+      => "9stuff")


### PR DESCRIPTION
Added a monad instance, and a `dofuture` macro to make use of `map` and `flatmap` (the two most used combinators) more pleasant, so that instead of writing...

```clojure
(f/flatmap (some-gateway-call "arg1" :arg2) [res1]
  (f/flatmap (a-dependent-call res1) [res2]
    (f/value (op res1 res2))))
```

we can write...

```clojure
(dofuture [res1 (some-gateway-call "arg1" :arg2)
            res2 (a-dependent-call res1)]
  (op res1 res2))
```

