### PR TITLE
Create a test helper future=

### DIFF
--- a/core/src/finagle_clojure/util/test_helpers.clj
+++ b/core/src/finagle_clojure/util/test_helpers.clj
@@ -1,0 +1,15 @@
+(ns finagle-clojure.util.test-helpers
+  (:require [midje.sweet :refer :all]
+            [midje.checking.core :as checking]
+            [finagle-clojure.futures :as fut])
+  (:import (com.twitter.util ConstFuture Promise)))
+
+(defchecker future= [expected]
+            (checker [actual]
+                     (if-not (or (instance? Promise actual) (instance? ConstFuture actual))
+                       (checking/as-data-laden-falsehood {:notes [(str "Expected a Future/Promise object but got a " (class actual) ": " actual)]})
+                       (let [actual-value (fut/await actual)]
+                         (if (= expected actual-value)
+                           true
+                           (checking/as-data-laden-falsehood {:notes [(str "Expected value " expected)
+                                                                      (str "Actual value " actual-value)]}))))))

--- a/core/test/finagle_clojure/test_helpers_test.clj
+++ b/core/test/finagle_clojure/test_helpers_test.clj
@@ -1,0 +1,8 @@
+(ns finagle-clojure.test-helpers-test
+  (:require [midje.sweet :refer :all]
+            [finagle-clojure.util.test-helpers :refer [future=]]
+            [finagle-clojure.futures :as fut]))
+
+(fact "future="
+      (fut/value true) => (future= true)
+      (fut/value "string") => (future= "string"))


### PR DESCRIPTION
Today, when we need to test a function that returns a future using Midje, we need to call await before to get the value of the future. Eg:

`(await (function "x")) => true`

To avoid a repetition of awaits on the code, I created a Midje checker called future=, so the same code above now looks like:

`(function "x") => (future= true)`

It's more explicit that the function returns a future, and we don't need to call await directly on my Midje facts.

We're using this checker here at Nubank, and as we have two projects that are using finagle-clojure, I replicated the same checker for both projects. That's the reason for this PR.

WDYT?
